### PR TITLE
Removed hardcoded `stable` toolchain for contract build

### DIFF
--- a/pysrc/__init__.py
+++ b/pysrc/__init__.py
@@ -52,7 +52,7 @@ def build_contract(package_name, build_mode, target_dir, stack_size):
     os.environ['RUSTC_BOOTSTRAP'] = '1'
     print(f"RUSTC_BOOTSTRAP=\"{os.environ['RUSTC_BOOTSTRAP']}\"")
     print(f"RUSTFLAGS=\"{os.environ['RUSTFLAGS']}\"")
-    cmd = fr'cargo +stable build --target=wasm32-wasi --target-dir={target_dir} -Zbuild-std --no-default-features {build_mode} -Zbuild-std-features=panic_immediate_abort'
+    cmd = fr'cargo build --target=wasm32-wasi --target-dir={target_dir} -Zbuild-std --no-default-features {build_mode} -Zbuild-std-features=panic_immediate_abort'
     print(cmd)
     cmd = shlex.split(cmd)
     ret_code = subprocess.call(cmd, stdout=sys.stdout, stderr=sys.stderr)


### PR DESCRIPTION
This PR addresses #3 to fix an issue with the `rscdk`:

https://github.com/uuosio/rscdk/issues/8

It simply removes the hardcoded `+stable` channel to allow users to decide which toolchain to use.